### PR TITLE
Update dialog.py

### DIFF
--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -280,7 +280,7 @@ class AppDialog(QtGui.QWidget):
 
             fields = {}
 
-            fields["Projectcode"] = project_code
+            fields["projectcode"] = project_code
             fields["Sequence"] = sequence_name
             fields["Shot"] = shot_name
             fields["version"] = version_number


### PR DESCRIPTION
Apparently the projectcode is expected to be in a field named 'projectcode', rather than 'Projectcode'. See this error:
2023-02-27 13:14:36,983 [    INFO] [PROXY] Something went wrong... Tried to resolve a path from the template  and a set of input fields '{'Projectcode': 'p23307', 'Sequence': 'sc0060', 'Shot': 'sh070', 'version': 8}' but the following required fields were missing from the input: ['projectcode']

Weird, but this change seems to fix the problem.